### PR TITLE
Check input before entering while loop in main

### DIFF
--- a/code/cellular_automaton/src/conways_game_of_life/life.cpp
+++ b/code/cellular_automaton/src/conways_game_of_life/life.cpp
@@ -46,12 +46,12 @@ int main()
     char c;
     cout << "\nPress return to create a new generation and press x to exit!\n";
     cin.get(c);
-    do {
+     while (c == '\n') {
         generation(world, gen);
         display(world, fout, gen);
         cout << "\nPress return to create a new generation and press x to exit!\n";
         cin.get(c);
-    } while (c == '\n');
+    }
 
     return 0;
 }


### PR DESCRIPTION
**Fixes issue:**
In life.cpp, the user input is checked after the loop executes. If the user did not want to continue, the loop would still be executed at least once more.


**Changes:**
Changed from "do-while" loop to "while" loop to check user input before proceeding into the loop.